### PR TITLE
Updated dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var cssInlineImages = require('css-inline-images'),
-    PluginError     = require('gulp-util/lib/PluginError'),
+    PluginError     = require('plugin-error'),
     through         = require('through2'),
 
     pluginName      = 'gulp-css-inline-images';

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "homepage": "https://github.com/driebit/gulp-css-inline-images",
   "dependencies": {
     "css-inline-images": "^0.1.0",
-    "gulp-util": "^3.0.1",
+    "plugin-error": "^1.0.1",
     "through2": "^0.6.3"
   },
   "devDependencies": {
-    "gulp": "^3.8.10"
+    "gulp": "^4.0.0"
   }
 }


### PR DESCRIPTION
gulp-util is deprecated, PluginError replaced with plugin-error library. also bumped gulp version to 4.0